### PR TITLE
Add missing XML documentation comments

### DIFF
--- a/src/Titanium.Web.Proxy/Certificates/Cache/CachedCertificate.cs
+++ b/src/Titanium.Web.Proxy/Certificates/Cache/CachedCertificate.cs
@@ -4,20 +4,27 @@ using System.Security.Cryptography.X509Certificates;
 namespace Titanium.Web.Proxy.Network;
 
 /// <summary>
-///     An object that holds the cached certificate
+/// An object that holds the cached certificate.
 /// </summary>
 internal sealed class CachedCertificate
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CachedCertificate"/> class.
+    /// </summary>
+    /// <param name="certificate">The certificate to cache.</param>
     public CachedCertificate(X509Certificate2 certificate)
     {
         Certificate = certificate;
     }
 
+    /// <summary>
+    /// Gets the cached certificate.
+    /// </summary>
     internal X509Certificate2 Certificate { get; }
 
     /// <summary>
-    ///     Last time this certificate was used.
-    ///     Useful in determining its cache lifetime.
+    /// Gets or sets the last time this certificate was used.
+    /// Useful in determining its cache lifetime.
     /// </summary>
     internal DateTime LastAccess { get; set; }
 }

--- a/src/Titanium.Web.Proxy/Certificates/Cache/DefaultCertificateDiskCache.cs
+++ b/src/Titanium.Web.Proxy/Certificates/Cache/DefaultCertificateDiskCache.cs
@@ -6,6 +6,9 @@ using Titanium.Web.Proxy.Helpers;
 
 namespace Titanium.Web.Proxy.Network;
 
+/// <summary>
+/// Provides a default disk-based cache implementation for storing certificates.
+/// </summary>
 public sealed class DefaultCertificateDiskCache : ICertificateCache
 {
     private const string DefaultCertificateDirectoryName = "crts";
@@ -13,12 +16,25 @@ public sealed class DefaultCertificateDiskCache : ICertificateCache
     private const string DefaultRootCertificateFileName = "rootCert" + DefaultCertificateFileExtension;
     private string? rootCertificatePath;
 
+    /// <summary>
+    /// Loads the root certificate from the specified path or name.
+    /// </summary>
+    /// <param name="pathOrName">The path or name of the root certificate.</param>
+    /// <param name="password">The password for the root certificate.</param>
+    /// <param name="storageFlags">The storage flags for the root certificate.</param>
+    /// <returns>The loaded root certificate, or null if not found.</returns>
     public X509Certificate2? LoadRootCertificate(string pathOrName, string password, X509KeyStorageFlags storageFlags)
     {
         var path = GetRootCertificatePath(pathOrName);
         return LoadCertificate(path, password, storageFlags);
     }
 
+    /// <summary>
+    /// Saves the root certificate to the specified path or name.
+    /// </summary>
+    /// <param name="pathOrName">The path or name where the root certificate will be saved.</param>
+    /// <param name="password">The password for the root certificate.</param>
+    /// <param name="certificate">The root certificate to save.</param>
     public void SaveRootCertificate(string pathOrName, string password, X509Certificate2 certificate)
     {
         var path = GetRootCertificatePath(pathOrName);
@@ -26,14 +42,23 @@ public sealed class DefaultCertificateDiskCache : ICertificateCache
         File.WriteAllBytes(path, exported);
     }
 
-    /// <inheritdoc />
+    /// <summary>
+    /// Loads a certificate from the specified subject name.
+    /// </summary>
+    /// <param name="subjectName">The subject name of the certificate to load.</param>
+    /// <param name="storageFlags">The storage flags for the certificate.</param>
+    /// <returns>The loaded certificate, or null if not found.</returns>
     public X509Certificate2? LoadCertificate(string subjectName, X509KeyStorageFlags storageFlags)
     {
         var filePath = Path.Combine(GetCertificatePath(false), subjectName + DefaultCertificateFileExtension);
         return LoadCertificate(filePath, string.Empty, storageFlags);
     }
 
-    /// <inheritdoc />
+    /// <summary>
+    /// Saves a certificate with the specified subject name.
+    /// </summary>
+    /// <param name="subjectName">The subject name of the certificate to save.</param>
+    /// <param name="certificate">The certificate to save.</param>
     public void SaveCertificate(string subjectName, X509Certificate2 certificate)
     {
         var filePath = Path.Combine(GetCertificatePath(true), subjectName + DefaultCertificateFileExtension);
@@ -41,6 +66,9 @@ public sealed class DefaultCertificateDiskCache : ICertificateCache
         File.WriteAllBytes(filePath, exported);
     }
 
+    /// <summary>
+    /// Clears all certificates from the cache.
+    /// </summary>
     public void Clear()
     {
         try

--- a/src/Titanium.Web.Proxy/Certificates/Cache/ICertificateCache.cs
+++ b/src/Titanium.Web.Proxy/Certificates/Cache/ICertificateCache.cs
@@ -2,30 +2,45 @@
 
 namespace Titanium.Web.Proxy.Network;
 
+/// <summary>
+/// Interface for certificate cache management.
+/// </summary>
 public interface ICertificateCache
 {
     /// <summary>
-    ///     Loads the root certificate from the storage.
+    /// Loads the root certificate from the storage.
     /// </summary>
+    /// <param name="pathOrName">The path or name of the root certificate.</param>
+    /// <param name="password">The password for the root certificate.</param>
+    /// <param name="storageFlags">The storage flags for the root certificate.</param>
+    /// <returns>The loaded root certificate, or null if not found.</returns>
     X509Certificate2? LoadRootCertificate(string pathOrName, string password, X509KeyStorageFlags storageFlags);
 
     /// <summary>
-    ///     Saves the root certificate to the storage.
+    /// Saves the root certificate to the storage.
     /// </summary>
+    /// <param name="pathOrName">The path or name where the root certificate will be saved.</param>
+    /// <param name="password">The password for the root certificate.</param>
+    /// <param name="certificate">The root certificate to save.</param>
     void SaveRootCertificate(string pathOrName, string password, X509Certificate2 certificate);
 
     /// <summary>
-    ///     Loads certificate from the storage. Returns true if certificate does not exist.
+    /// Loads a certificate from the storage.
     /// </summary>
+    /// <param name="subjectName">The subject name of the certificate to load.</param>
+    /// <param name="storageFlags">The storage flags for the certificate.</param>
+    /// <returns>The loaded certificate, or null if not found.</returns>
     X509Certificate2? LoadCertificate(string subjectName, X509KeyStorageFlags storageFlags);
 
     /// <summary>
-    ///     Stores certificate into the storage.
+    /// Saves a certificate to the storage.
     /// </summary>
+    /// <param name="subjectName">The subject name of the certificate to save.</param>
+    /// <param name="certificate">The certificate to save.</param>
     void SaveCertificate(string subjectName, X509Certificate2 certificate);
 
     /// <summary>
-    ///     Clears the storage.
+    /// Clears all certificates from the storage.
     /// </summary>
     void Clear();
 }

--- a/src/Titanium.Web.Proxy/Certificates/CertificateManager.cs
+++ b/src/Titanium.Web.Proxy/Certificates/CertificateManager.cs
@@ -14,28 +14,28 @@ using Titanium.Web.Proxy.Shared;
 namespace Titanium.Web.Proxy.Network;
 
 /// <summary>
-///     Certificate Engine option.
+/// Certificate Engine option.
 /// </summary>
 public enum CertificateEngine
 {
     /// <summary>
-    ///     Uses BouncyCastle 3rd party library.
-    ///     Default.
+    /// Uses BouncyCastle 3rd party library.
+    /// Default.
     /// </summary>
     BouncyCastle = 0,
 
     BouncyCastleFast = 2,
 
     /// <summary>
-    ///     Uses Windows Certification Generation API and only valid in Windows OS.
-    ///     Observed to be faster than BouncyCastle.
-    ///     Bug #468 Reported.
+    /// Uses Windows Certification Generation API and only valid in Windows OS.
+    /// Observed to be faster than BouncyCastle.
+    /// Bug #468 Reported.
     /// </summary>
     DefaultWindows = 1
 }
 
 /// <summary>
-///     A class to manage SSL certificates used by this proxy server.
+/// A class to manage SSL certificates used by this proxy server.
 /// </summary>
 public sealed class CertificateManager : IDisposable
 {
@@ -46,20 +46,20 @@ public sealed class CertificateManager : IDisposable
     private static readonly ConcurrentDictionary<string, object> _saveCertificateLocks = new();
 
     /// <summary>
-    ///     Cache dictionary
+    /// Cache dictionary
     /// </summary>
     private readonly ConcurrentDictionary<string, CachedCertificate> cachedCertificates = new();
 
     private readonly CancellationTokenSource clearCertificatesTokenSource = new();
 
     /// <summary>
-    ///     Used to prevent multiple threads working on same certificate generation
-    ///     when burst certificate generation requests happen for same certificate.
+    /// Used to prevent multiple threads working on same certificate generation
+    /// when burst certificate generation requests happen for same certificate.
     /// </summary>
     private readonly SemaphoreSlim pendingCertificateCreationTaskLock = new(1);
 
     /// <summary>
-    ///     A list of pending certificate creation tasks.
+    /// A list of pending certificate creation tasks.
     /// </summary>
     private readonly Dictionary<string, Task<X509Certificate2?>> pendingCertificateCreationTasks = new();
 
@@ -80,18 +80,18 @@ public sealed class CertificateManager : IDisposable
     private string? rootCertificateName;
 
     /// <summary>
-    ///     Initializes a new instance of the <see cref="CertificateManager" /> class.
+    /// Initializes a new instance of the <see cref="CertificateManager" /> class.
     /// </summary>
     /// <param name="rootCertificateName"></param>
     /// <param name="rootCertificateIssuerName"></param>
     /// <param name="userTrustRootCertificate">
-    ///     Should fake HTTPS certificate be trusted by this machine's user certificate
-    ///     store?
+    /// Should fake HTTPS certificate be trusted by this machine's user certificate
+    /// store?
     /// </param>
     /// <param name="machineTrustRootCertificate">Should fake HTTPS certificate be trusted by this machine's certificate store?</param>
     /// <param name="trustRootCertificateAsAdmin">
-    ///     Should we attempt to trust certificates with elevated permissions by
-    ///     prompting for UAC if required?
+    /// Should we attempt to trust certificates with elevated permissions by
+    /// prompting for UAC if required?
     /// </param>
     /// <param name="exceptionFunc"></param>
     internal CertificateManager(string? rootCertificateName, string? rootCertificateIssuerName,
@@ -136,36 +136,36 @@ public sealed class CertificateManager : IDisposable
     }
 
     /// <summary>
-    ///     Is the root certificate used by this proxy is valid?
+    /// Is the root certificate used by this proxy is valid?
     /// </summary>
     internal bool CertValidated => RootCertificate != null;
 
     /// <summary>
-    ///     Trust the RootCertificate used by this proxy server for current user
+    /// Trust the RootCertificate used by this proxy server for current user
     /// </summary>
     internal bool UserTrustRoot { get; set; }
 
     /// <summary>
-    ///     Trust the RootCertificate used by this proxy server for current machine
-    ///     Needs elevated permission, otherwise will fail silently.
+    /// Trust the RootCertificate used by this proxy server for current machine
+    /// Needs elevated permission, otherwise will fail silently.
     /// </summary>
     internal bool MachineTrustRoot { get; set; }
 
     /// <summary>
-    ///     Whether trust operations should be done with elevated privileges
-    ///     Will prompt with UAC if required. Works only on Windows.
+    /// Whether trust operations should be done with elevated privileges
+    /// Will prompt with UAC if required. Works only on Windows.
     /// </summary>
     internal bool TrustRootAsAdministrator { get; set; }
 
     /// <summary>
-    ///     Exception handler
+    /// Exception handler
     /// </summary>
     internal ExceptionHandler? ExceptionFunc { get; set; }
 
     /// <summary>
-    ///     Select Certificate Engine.
-    ///     Optionally set to BouncyCastle.
-    ///     Mono only support BouncyCastle and it is the default.
+    /// Select Certificate Engine.
+    /// Optionally set to BouncyCastle.
+    /// Mono only support BouncyCastle and it is the default.
     /// </summary>
     public CertificateEngine CertificateEngine
     {
@@ -184,29 +184,29 @@ public sealed class CertificateManager : IDisposable
     }
 
     /// <summary>
-    ///     Password of the Root certificate file.
-    ///     <para>Set a password for the .pfx file</para>
+    /// Password of the Root certificate file.
+    /// <para>Set a password for the .pfx file</para>
     /// </summary>
     public string PfxPassword { get; set; } = string.Empty;
 
     /// <summary>
-    ///     Name(path) of the Root certificate file.
-    ///     <para>
-    ///         Set the name(path) of the .pfx file. If it is string.Empty Root certificate file will be named as
-    ///         "rootCert.pfx" (and will be saved in proxy dll directory)
-    ///     </para>
+    /// Name(path) of the Root certificate file.
+    /// <para>
+    /// Set the name(path) of the .pfx file. If it is string.Empty Root certificate file will be named as
+    /// "rootCert.pfx" (and will be saved in proxy dll directory)
+    /// </para>
     /// </summary>
     public string PfxFilePath { get; set; } = string.Empty;
 
     /// <summary>
-    ///     Number of Days generated HTTPS certificates are valid for.
-    ///     Maximum allowed on iOS 13 is 825 days and it is the default.
+    /// Number of Days generated HTTPS certificates are valid for.
+    /// Maximum allowed on iOS 13 is 825 days and it is the default.
     /// </summary>
     public int CertificateValidDays { get; set; } = 825;
 
     /// <summary>
-    ///     Name of the root certificate issuer.
-    ///     (This is valid only when RootCertificate property is not set.)
+    /// Name of the root certificate issuer.
+    /// (This is valid only when RootCertificate property is not set.)
     /// </summary>
     public string RootCertificateIssuerName
     {
@@ -215,11 +215,11 @@ public sealed class CertificateManager : IDisposable
     }
 
     /// <summary>
-    ///     Name of the root certificate.
-    ///     (This is valid only when RootCertificate property is not set.)
-    ///     If no certificate is provided then a default Root Certificate will be created and used.
-    ///     The provided root certificate will be stored in proxy exe directory with the private key.
-    ///     Root certificate file will be named as "rootCert.pfx".
+    /// Name of the root certificate.
+    /// (This is valid only when RootCertificate property is not set.)
+    /// If no certificate is provided then a default Root Certificate will be created and used.
+    /// The provided root certificate will be stored in proxy exe directory with the private key.
+    /// Root certificate file will be named as "rootCert.pfx".
     /// </summary>
     public string RootCertificateName
     {
@@ -228,7 +228,7 @@ public sealed class CertificateManager : IDisposable
     }
 
     /// <summary>
-    ///     The root certificate.
+    /// The root certificate.
     /// </summary>
     public X509Certificate2? RootCertificate
     {
@@ -241,16 +241,16 @@ public sealed class CertificateManager : IDisposable
     }
 
     /// <summary>
-    ///     Save all fake certificates using <seealso cref="CertificateStorage" />.
-    ///     <para>for can load the certificate and not make new certificate every time. </para>
+    /// Save all fake certificates using <seealso cref="CertificateStorage" />.
+    /// <para>for can load the certificate and not make new certificate every time. </para>
     /// </summary>
     public bool SaveFakeCertificates { get; set; } = false;
 
     /// <summary>
-    ///     The fake certificate cache storage.
-    ///     The default cache storage implementation saves certificates in folder "crts" (will be created in proxy dll
-    ///     directory).
-    ///     Implement ICertificateCache interface and assign concrete class here to customize.
+    /// The fake certificate cache storage.
+    /// The default cache storage implementation saves certificates in folder "crts" (will be created in proxy dll
+    /// directory).
+    /// Implement ICertificateCache interface and assign concrete class here to customize.
     /// </summary>
     public ICertificateCache CertificateStorage
     {
@@ -259,23 +259,23 @@ public sealed class CertificateManager : IDisposable
     }
 
     /// <summary>
-    ///     Overwrite Root certificate file.
-    ///     <para>true : replace an existing .pfx file if password is incorrect or if RootCertificate = null.</para>
+    /// Overwrite Root certificate file.
+    /// <para>true : replace an existing .pfx file if password is incorrect or if RootCertificate = null.</para>
     /// </summary>
     public bool OverwritePfxFile { get; set; } = true;
 
     /// <summary>
-    ///     Minutes certificates should be kept in cache when not used.
+    /// Minutes certificates should be kept in cache when not used.
     /// </summary>
     public int CertificateCacheTimeOutMinutes { get; set; } = 60;
 
     /// <summary>
-    ///     Adjust behaviour when certificates are saved to filesystem.
+    /// Adjust behaviour when certificates are saved to filesystem.
     /// </summary>
     public X509KeyStorageFlags StorageFlag { get; set; } = X509KeyStorageFlags.Exportable;
 
     /// <summary>
-    ///     Disable wild card certificates. Disabled by default.
+    /// Disable wild card certificates. Disabled by default.
     /// </summary>
     public bool DisableWildCardCertificates { get; set; } = false;
 
@@ -286,7 +286,7 @@ public sealed class CertificateManager : IDisposable
     }
 
     /// <summary>
-    ///     For CertificateEngine.DefaultWindows to work we need to also check in personal store
+    /// For CertificateEngine.DefaultWindows to work we need to also check in personal store
     /// </summary>
     /// <param name="storeLocation"></param>
     /// <returns></returns>
@@ -316,7 +316,7 @@ public sealed class CertificateManager : IDisposable
     }
 
     /// <summary>
-    ///     Make current machine trust the Root Certificate used by this proxy
+    /// Make current machine trust the Root Certificate used by this proxy
     /// </summary>
     /// <param name="storeName"></param>
     /// <param name="storeLocation"></param>
@@ -347,7 +347,7 @@ public sealed class CertificateManager : IDisposable
     }
 
     /// <summary>
-    ///     Remove the Root Certificate trust
+    /// Remove the Root Certificate trust
     /// </summary>
     /// <param name="storeName"></param>
     /// <param name="storeLocation"></param>
@@ -404,7 +404,7 @@ public sealed class CertificateManager : IDisposable
     }
 
     /// <summary>
-    ///     Create an SSL certificate
+    /// Create an SSL certificate
     /// </summary>
     /// <param name="certificateName"></param>
     /// <param name="isRootCertificate"></param>
@@ -484,7 +484,7 @@ public sealed class CertificateManager : IDisposable
     }
 
     /// <summary>
-    ///     Creates a server certificate signed by the root certificate.
+    /// Creates a server certificate signed by the root certificate.
     /// </summary>
     /// <param name="certificateName"></param>
     /// <returns></returns>
@@ -551,7 +551,7 @@ public sealed class CertificateManager : IDisposable
     }
 
     /// <summary>
-    ///     A method to clear outdated certificates
+    /// A method to clear outdated certificates
     /// </summary>
     internal async void ClearIdleCertificates()
     {
@@ -577,7 +577,7 @@ public sealed class CertificateManager : IDisposable
     }
 
     /// <summary>
-    ///     Stops the certificate cache clear process
+    /// Stops the certificate cache clear process
     /// </summary>
     internal void StopClearIdleCertificates()
     {
@@ -585,11 +585,11 @@ public sealed class CertificateManager : IDisposable
     }
 
     /// <summary>
-    ///     Attempts to create a RootCertificate.
+    /// Attempts to create a RootCertificate.
     /// </summary>
     /// <param name="persistToFile">if set to <c>true</c> try to load/save the certificate from rootCert.pfx.</param>
     /// <returns>
-    ///     true if succeeded, else false.
+    /// true if succeeded, else false.
     /// </returns>
     public bool CreateRootCertificate(bool persistToFile = true)
     {
@@ -656,7 +656,7 @@ public sealed class CertificateManager : IDisposable
     }
 
     /// <summary>
-    ///     Loads root certificate from current executing assembly location with expected name rootCert.pfx.
+    /// Loads root certificate from current executing assembly location with expected name rootCert.pfx.
     /// </summary>
     /// <returns></returns>
     public X509Certificate2? LoadRootCertificate()
@@ -682,20 +682,20 @@ public sealed class CertificateManager : IDisposable
     }
 
     /// <summary>
-    ///     Manually load a Root certificate file from give path (.pfx file).
+    /// Manually load a Root certificate file from give path (.pfx file).
     /// </summary>
     /// <param name="pfxFilePath">
-    ///     Set the name(path) of the .pfx file. If it is string.Empty Root certificate file will be
-    ///     named as "rootCert.pfx" (and will be saved in proxy dll directory).
+    /// Set the name(path) of the .pfx file. If it is string.Empty Root certificate file will be
+    /// named as "rootCert.pfx" (and will be saved in proxy dll directory).
     /// </param>
     /// <param name="password">Set a password for the .pfx file.</param>
     /// <param name="overwritePfXFile">
-    ///     true : replace an existing .pfx file if password is incorrect or if
-    ///     RootCertificate==null.
+    /// true : replace an existing .pfx file if password is incorrect or if
+    /// RootCertificate==null.
     /// </param>
     /// <param name="storageFlag"></param>
     /// <returns>
-    ///     true if succeeded, else false.
+    /// true if succeeded, else false.
     /// </returns>
     public bool LoadRootCertificate(string pfxFilePath, string password, bool overwritePfXFile = true,
         X509KeyStorageFlags storageFlag = X509KeyStorageFlags.Exportable)
@@ -711,8 +711,8 @@ public sealed class CertificateManager : IDisposable
     }
 
     /// <summary>
-    ///     Trusts the root certificate in user store, optionally also in machine store.
-    ///     Machine trust would require elevated permissions (will silently fail otherwise).
+    /// Trusts the root certificate in user store, optionally also in machine store.
+    /// Machine trust would require elevated permissions (will silently fail otherwise).
     /// </summary>
     public void TrustRootCertificate(bool machineTrusted = false)
     {
@@ -735,8 +735,8 @@ public sealed class CertificateManager : IDisposable
     }
 
     /// <summary>
-    ///     Puts the certificate to the user store, optionally also to machine store.
-    ///     Prompts with UAC if elevated permissions are required. Works only on Windows.
+    /// Puts the certificate to the user store, optionally also to machine store.
+    /// Prompts with UAC if elevated permissions are required. Works only on Windows.
     /// </summary>
     /// <returns>True if success.</returns>
     public bool TrustRootCertificateAsAdmin(bool machineTrusted = false)
@@ -783,8 +783,8 @@ public sealed class CertificateManager : IDisposable
     }
 
     /// <summary>
-    ///     Ensure certificates are setup (creates root if required).
-    ///     Also makes root certificate trusted based on initial setup from proxy constructor for user/machine trust.
+    /// Ensure certificates are setup (creates root if required).
+    /// Also makes root certificate trusted based on initial setup from proxy constructor for user/machine trust.
     /// </summary>
     public void EnsureRootCertificate()
     {
@@ -796,18 +796,18 @@ public sealed class CertificateManager : IDisposable
     }
 
     /// <summary>
-    ///     Ensure certificates are setup (creates root if required).
-    ///     Also makes root certificate trusted based on provided parameters.
-    ///     Note:setting machineTrustRootCertificate to true will force userTrustRootCertificate to true.
+    /// Ensure certificates are setup (creates root if required).
+    /// Also makes root certificate trusted based on provided parameters.
+    /// Note:setting machineTrustRootCertificate to true will force userTrustRootCertificate to true.
     /// </summary>
     /// <param name="userTrustRootCertificate">
-    ///     Should fake HTTPS certificate be trusted by this machine's user certificate
-    ///     store?
+    /// Should fake HTTPS certificate be trusted by this machine's user certificate
+    /// store?
     /// </param>
     /// <param name="machineTrustRootCertificate">Should fake HTTPS certificate be trusted by this machine's certificate store?</param>
     /// <param name="trustRootCertificateAsAdmin">
-    ///     Should we attempt to trust certificates with elevated permissions by
-    ///     prompting for UAC if required?
+    /// Should we attempt to trust certificates with elevated permissions by
+    /// prompting for UAC if required?
     /// </param>
     public void EnsureRootCertificate(bool userTrustRootCertificate,
         bool machineTrustRootCertificate, bool trustRootCertificateAsAdmin = false)
@@ -820,7 +820,7 @@ public sealed class CertificateManager : IDisposable
     }
 
     /// <summary>
-    ///     Determines whether the root certificate is trusted.
+    /// Determines whether the root certificate is trusted.
     /// </summary>
     public bool IsRootCertificateUserTrusted()
     {
@@ -828,7 +828,7 @@ public sealed class CertificateManager : IDisposable
     }
 
     /// <summary>
-    ///     Determines whether the root certificate is machine trusted.
+    /// Determines whether the root certificate is machine trusted.
     /// </summary>
     public bool IsRootCertificateMachineTrusted()
     {
@@ -836,8 +836,8 @@ public sealed class CertificateManager : IDisposable
     }
 
     /// <summary>
-    ///     Removes the trusted certificates from user store, optionally also from machine store.
-    ///     To remove from machine store elevated permissions are required (will fail silently otherwise).
+    /// Removes the trusted certificates from user store, optionally also from machine store.
+    /// To remove from machine store elevated permissions are required (will fail silently otherwise).
     /// </summary>
     /// <param name="machineTrusted">Should also remove from machine store?</param>
     public void RemoveTrustedRootCertificate(bool machineTrusted = false)
@@ -861,7 +861,7 @@ public sealed class CertificateManager : IDisposable
     }
 
     /// <summary>
-    ///     Removes the trusted certificates from user store, optionally also from machine store
+    /// Removes the trusted certificates from user store, optionally also from machine store
     /// </summary>
     /// <returns>Should also remove from machine store?</returns>
     public bool RemoveTrustedRootCertificateAsAdmin(bool machineTrusted = false)
@@ -933,7 +933,7 @@ public sealed class CertificateManager : IDisposable
     }
 
     /// <summary>
-    ///     Clear the root certificate and cache.
+    /// Clear the root certificate and cache.
     /// </summary>
     public void ClearRootCertificate()
     {

--- a/src/Titanium.Web.Proxy/EventArguments/BeforeBodyWriteEventArgs.cs
+++ b/src/Titanium.Web.Proxy/EventArguments/BeforeBodyWriteEventArgs.cs
@@ -1,13 +1,11 @@
 ﻿#if DEBUG
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Titanium.Web.Proxy.EventArguments
 {
-
+    /// <summary>
+    /// Event arguments for <see cref="BeforeBodyWriteEventArgs"/>.
+    /// </summary>
     public class BeforeBodyWriteEventArgs : ProxyEventArgsBase
     {
         internal BeforeBodyWriteEventArgs(SessionEventArgs session, byte[] bodyBytes, bool isChunked, bool isLastChunk) : base(session.Server, session.ClientConnection)
@@ -18,15 +16,14 @@ namespace Titanium.Web.Proxy.EventArguments
             IsLastChunk = isLastChunk;
         }
 
-
-        /// <value>
-        ///     The session arguments.
-        /// </value>
+        /// <summary>
+        /// Gets the session arguments.
+        /// </summary>
         public SessionEventArgs Session { get; }
 
         /// <summary>
-        ///  Indicates whether body is written chunked stream.
-        ///  If this is true, BeforeRequestBodySend or BeforeResponseBodySend will be called until IsLastChunk is false.
+        /// Indicates whether body is written chunked stream.
+        /// If this is true, BeforeRequestBodySend or BeforeResponseBodySend will be called until IsLastChunk is false.
         /// </summary>
         public bool IsChunked { get; }
 

--- a/src/Titanium.Web.Proxy/EventArguments/BeforeSslAuthenticateEventArgs.cs
+++ b/src/Titanium.Web.Proxy/EventArguments/BeforeSslAuthenticateEventArgs.cs
@@ -10,6 +10,13 @@ public class BeforeSslAuthenticateEventArgs : ProxyEventArgsBase
 {
     internal readonly CancellationTokenSource TaskCancellationSource;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BeforeSslAuthenticateEventArgs"/> class.
+    /// </summary>
+    /// <param name="server">The proxy server instance.</param>
+    /// <param name="clientConnection">The client connection.</param>
+    /// <param name="taskCancellationSource">The task cancellation source.</param>
+    /// <param name="sniHostName">The server name indication hostname.</param>
     internal BeforeSslAuthenticateEventArgs(ProxyServer server, TcpClientConnection clientConnection,
         CancellationTokenSource taskCancellationSource, string sniHostName) : base(server, clientConnection)
     {

--- a/src/Titanium.Web.Proxy/EventArguments/CertificateSelectionEventArgs.cs
+++ b/src/Titanium.Web.Proxy/EventArguments/CertificateSelectionEventArgs.cs
@@ -7,6 +7,14 @@ namespace Titanium.Web.Proxy.EventArguments;
 /// </summary>
 public class CertificateSelectionEventArgs : ProxyEventArgsBase
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CertificateSelectionEventArgs"/> class.
+    /// </summary>
+    /// <param name="session">The session event arguments.</param>
+    /// <param name="targetHost">The target host.</param>
+    /// <param name="localCertificates">The local certificates.</param>
+    /// <param name="remoteCertificate">The remote certificate.</param>
+    /// <param name="acceptableIssuers">The acceptable issuers.</param>
     public CertificateSelectionEventArgs(SessionEventArgsBase session, string targetHost,
         X509CertificateCollection localCertificates, X509Certificate? remoteCertificate, string[] acceptableIssuers) :
         base(session.Server, session.ClientConnection)

--- a/src/Titanium.Web.Proxy/EventArguments/CertificateValidationEventArgs.cs
+++ b/src/Titanium.Web.Proxy/EventArguments/CertificateValidationEventArgs.cs
@@ -9,6 +9,13 @@ namespace Titanium.Web.Proxy.EventArguments;
 /// </summary>
 public class CertificateValidationEventArgs : ProxyEventArgsBase
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CertificateValidationEventArgs"/> class.
+    /// </summary>
+    /// <param name="session">The session.</param>
+    /// <param name="certificate">The certificate.</param>
+    /// <param name="chain">The chain.</param>
+    /// <param name="sslPolicyErrors">The SSL policy errors.</param>
     public CertificateValidationEventArgs(SessionEventArgsBase session, X509Certificate certificate, X509Chain chain,
         SslPolicyErrors sslPolicyErrors) : base(session.Server, session.ClientConnection)
     {

--- a/src/Titanium.Web.Proxy/EventArguments/DataEventArgs.cs
+++ b/src/Titanium.Web.Proxy/EventArguments/DataEventArgs.cs
@@ -7,6 +7,12 @@ namespace Titanium.Web.Proxy.StreamExtended.Network;
 /// </summary>
 public class DataEventArgs : EventArgs
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DataEventArgs"/> class.
+    /// </summary>
+    /// <param name="buffer">The buffer containing the data.</param>
+    /// <param name="offset">The offset in the buffer where the data begins.</param>
+    /// <param name="count">The number of bytes of data in the buffer.</param>
     public DataEventArgs(byte[] buffer, int offset, int count)
     {
         Buffer = buffer;

--- a/src/Titanium.Web.Proxy/EventArguments/EmptyProxyEventArgs.cs
+++ b/src/Titanium.Web.Proxy/EventArguments/EmptyProxyEventArgs.cs
@@ -2,8 +2,16 @@
 
 namespace Titanium.Web.Proxy.EventArguments;
 
+/// <summary>
+/// Represents the arguments for an empty proxy event.
+/// </summary>
 public class EmptyProxyEventArgs : ProxyEventArgsBase
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EmptyProxyEventArgs"/> class.
+    /// </summary>
+    /// <param name="server">The proxy server instance.</param>
+    /// <param name="clientConnection">The client connection.</param>
     internal EmptyProxyEventArgs(ProxyServer server, TcpClientConnection clientConnection) : base(server,
         clientConnection)
     {

--- a/src/Titanium.Web.Proxy/EventArguments/MultipartRequestPartSentEventArgs.cs
+++ b/src/Titanium.Web.Proxy/EventArguments/MultipartRequestPartSentEventArgs.cs
@@ -3,10 +3,16 @@
 namespace Titanium.Web.Proxy.EventArguments;
 
 /// <summary>
-///     Class that wraps the multipart sent request arguments.
+/// Class that wraps the multipart sent request arguments.
 /// </summary>
 public class MultipartRequestPartSentEventArgs : ProxyEventArgsBase
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MultipartRequestPartSentEventArgs"/> class.
+    /// </summary>
+    /// <param name="session">The session event arguments.</param>
+    /// <param name="boundary">The multipart boundary.</param>
+    /// <param name="headers">The multipart headers.</param>
     internal MultipartRequestPartSentEventArgs(SessionEventArgs session, string boundary, HeaderCollection headers) :
         base(session.Server, session.ClientConnection)
     {
@@ -15,18 +21,18 @@ public class MultipartRequestPartSentEventArgs : ProxyEventArgsBase
         Headers = headers;
     }
 
-    /// <value>
-    ///     The session arguments.
-    /// </value>
+    /// <summary>
+    /// Gets the session arguments.
+    /// </summary>
     public SessionEventArgs Session { get; }
 
     /// <summary>
-    ///     Boundary.
+    /// Gets the multipart boundary.
     /// </summary>
     public string Boundary { get; }
 
     /// <summary>
-    ///     The header collection.
+    /// Gets the multipart headers.
     /// </summary>
     public HeaderCollection Headers { get; }
 }

--- a/src/Titanium.Web.Proxy/EventArguments/ProxyEventArgsBase.cs
+++ b/src/Titanium.Web.Proxy/EventArguments/ProxyEventArgsBase.cs
@@ -4,7 +4,7 @@ using Titanium.Web.Proxy.Network.Tcp;
 namespace Titanium.Web.Proxy.EventArguments;
 
 /// <summary>
-///     The base event arguments
+///     The base event arguments.
 /// </summary>
 /// <seealso cref="System.EventArgs" />
 public abstract class ProxyEventArgsBase : EventArgs
@@ -12,12 +12,20 @@ public abstract class ProxyEventArgsBase : EventArgs
     private readonly TcpClientConnection clientConnection;
     internal readonly ProxyServer Server;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ProxyEventArgsBase"/> class.
+    /// </summary>
+    /// <param name="server">The proxy server instance.</param>
+    /// <param name="clientConnection">The client connection.</param>
     internal ProxyEventArgsBase(ProxyServer server, TcpClientConnection clientConnection)
     {
         this.clientConnection = clientConnection;
         Server = server;
     }
 
+    /// <summary>
+    /// Gets or sets the user data associated with the client.
+    /// </summary>
     public object? ClientUserData
     {
         get => clientConnection.ClientUserData;


### PR DESCRIPTION
Related to #8

This pull request addresses the issue of missing XML comments for publicly visible types or members in the Titanium Web Proxy project, specifically targeting event argument classes and ensuring compliance with the CS1591 warning.

- **Adds XML documentation comments** to various event argument classes within the `EventArguments` namespace, including `BeforeBodyWriteEventArgs`, `BeforeSslAuthenticateEventArgs`, `CertificateSelectionEventArgs`, `CertificateValidationEventArgs`, `DataEventArgs`, `EmptyProxyEventArgs`, `MultipartRequestPartSentEventArgs`, and `ProxyEventArgsBase`. These comments provide summaries for classes, constructors, properties, and methods, enhancing code readability and maintainability.
- **Improves code documentation** by clearly explaining the purpose and usage of each class and its members, which is crucial for developers working with or extending the Titanium Web Proxy library.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/svrooij/titanium-web-proxy/issues/8?shareId=aca9b98f-a0c6-4dd6-8c57-4e324eeec2e0).