### PR TITLE
Add XML documentation comments to public types and members

### DIFF
--- a/src/Titanium.Web.Proxy/Http/ConnectRequest.cs
+++ b/src/Titanium.Web.Proxy/Http/ConnectRequest.cs
@@ -8,13 +8,23 @@ namespace Titanium.Web.Proxy.Http;
 /// </summary>
 public class ConnectRequest : Request
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConnectRequest"/> class.
+    /// </summary>
+    /// <param name="authority">The authority.</param>
     internal ConnectRequest(ByteString authority)
     {
         Method = "CONNECT";
         Authority = authority;
     }
 
+    /// <summary>
+    /// Gets or sets the type of the tunnel.
+    /// </summary>
     public TunnelType TunnelType { get; internal set; }
 
+    /// <summary>
+    /// Gets or sets the client hello information.
+    /// </summary>
     public ClientHelloInfo? ClientHelloInfo { get; set; }
 }

--- a/src/Titanium.Web.Proxy/Http/ConnectResponse.cs
+++ b/src/Titanium.Web.Proxy/Http/ConnectResponse.cs
@@ -5,17 +5,20 @@ using Titanium.Web.Proxy.StreamExtended;
 namespace Titanium.Web.Proxy.Http;
 
 /// <summary>
-///     The tcp tunnel connect response object.
+/// The tcp tunnel connect response object.
 /// </summary>
 public class ConnectResponse : Response
 {
+    /// <summary>
+    /// Gets or sets the server hello information.
+    /// </summary>
     public ServerHelloInfo? ServerHelloInfo { get; set; }
 
     /// <summary>
-    ///     Creates a successful CONNECT response
+    /// Creates a successful CONNECT response.
     /// </summary>
-    /// <param name="httpVersion"></param>
-    /// <returns></returns>
+    /// <param name="httpVersion">The HTTP version.</param>
+    /// <returns>The <see cref="ConnectResponse"/>.</returns>
     internal static ConnectResponse CreateSuccessfulConnectResponse(Version httpVersion)
     {
         var response = new ConnectResponse

--- a/src/Titanium.Web.Proxy/Http/KnownHeader.cs
+++ b/src/Titanium.Web.Proxy/Http/KnownHeader.cs
@@ -4,32 +4,64 @@ using Titanium.Web.Proxy.Models;
 
 namespace Titanium.Web.Proxy.Http;
 
+/// <summary>
+/// Represents a known HTTP header.
+/// </summary>
 public class KnownHeader
 {
+    /// <summary>
+    /// The string representation of the header.
+    /// </summary>
     public string String;
+
+    /// <summary>
+    /// The ByteString representation of the header.
+    /// </summary>
     internal ByteString String8;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="KnownHeader"/> class.
+    /// </summary>
+    /// <param name="str">The string representation of the header.</param>
     private KnownHeader(string str)
     {
         String8 = (ByteString)str;
         String = str;
     }
 
+    /// <summary>
+    /// Returns a string that represents the current object.
+    /// </summary>
+    /// <returns>A string that represents the current object.</returns>
     public override string ToString()
     {
         return String;
     }
 
+    /// <summary>
+    /// Determines whether the specified value is equal to the current object.
+    /// </summary>
+    /// <param name="value">The value to compare with the current object.</param>
+    /// <returns>true if the specified value is equal to the current object; otherwise, false.</returns>
     internal bool Equals(ReadOnlySpan<char> value)
     {
         return String.AsSpan().EqualsIgnoreCase(value);
     }
 
+    /// <summary>
+    /// Determines whether the specified value is equal to the current object.
+    /// </summary>
+    /// <param name="value">The value to compare with the current object.</param>
+    /// <returns>true if the specified value is equal to the current object; otherwise, false.</returns>
     internal bool Equals(string? value)
     {
         return String.EqualsIgnoreCase(value);
     }
 
+    /// <summary>
+    /// Converts a string to a <see cref="KnownHeader"/>.
+    /// </summary>
+    /// <param name="str">The string to convert.</param>
     public static implicit operator KnownHeader(string str)
     {
         return new(str);

--- a/src/Titanium.Web.Proxy/Http/Request.cs
+++ b/src/Titanium.Web.Proxy/Http/Request.cs
@@ -7,7 +7,7 @@ using Titanium.Web.Proxy.Models;
 namespace Titanium.Web.Proxy.Http;
 
 /// <summary>
-///     Http(s) request object
+///     Http(s) request object.
 /// </summary>
 [TypeConverter(typeof(ExpandableObjectConverter))]
 public class Request : RequestResponseBase
@@ -15,12 +15,12 @@ public class Request : RequestResponseBase
     private ByteString requestUriString8;
 
     /// <summary>
-    ///     Request Method.
+    ///     Gets or sets the request method.
     /// </summary>
     public string? Method { get; set; }
 
     /// <summary>
-    ///     Is Https?
+    ///     Gets a value indicating whether the request is over HTTPS.
     /// </summary>
     public bool IsHttps { get; internal set; }
 
@@ -38,7 +38,7 @@ public class Request : RequestResponseBase
     internal ByteString Authority { get; set; }
 
     /// <summary>
-    ///     Request HTTP Uri.
+    ///     Gets or sets the request URI.
     /// </summary>
     public Uri RequestUri
     {
@@ -58,7 +58,7 @@ public class Request : RequestResponseBase
     }
 
     /// <summary>
-    ///     The request url as it is in the HTTP header
+    ///     Gets or sets the request URL as it appears in the HTTP header.
     /// </summary>
     public string Url
     {
@@ -83,7 +83,7 @@ public class Request : RequestResponseBase
     }
 
     /// <summary>
-    ///     The request uri as it is in the HTTP header
+    ///     Gets or sets the request URI as a string.
     /// </summary>
     public string RequestUriString
     {
@@ -103,7 +103,7 @@ public class Request : RequestResponseBase
     }
 
     /// <summary>
-    ///     Has request body?
+    ///     Gets a value indicating whether the request has a body.
     /// </summary>
     public override bool HasBody
     {
@@ -125,7 +125,7 @@ public class Request : RequestResponseBase
     }
 
     /// <summary>
-    ///     Http hostname header value if exists.
+    ///     Gets or sets the Http hostname header value if exists.
     ///     Note: Changing this does NOT change host in RequestUri.
     ///     Users can set new RequestUri separately.
     /// </summary>
@@ -136,7 +136,7 @@ public class Request : RequestResponseBase
     }
 
     /// <summary>
-    ///     Does this request has a 100-continue header?
+    ///     Gets a value indicating whether the request has a 100-continue header.
     /// </summary>
     public bool ExpectContinue
     {
@@ -148,7 +148,7 @@ public class Request : RequestResponseBase
     }
 
     /// <summary>
-    ///     Does this request contain multipart/form-data?
+    ///     Gets a value indicating whether the request contains multipart/form-data.
     /// </summary>
     public bool IsMultipartFormData => ContentType?.StartsWith("multipart/form-data") == true;
 
@@ -159,7 +159,7 @@ public class Request : RequestResponseBase
     internal bool CancelRequest { get; set; }
 
     /// <summary>
-    ///     Does this request has an upgrade to websocket header?
+    ///     Gets a value indicating whether the request has an upgrade to websocket header.
     /// </summary>
     public bool UpgradeToWebSocket
     {
@@ -174,12 +174,12 @@ public class Request : RequestResponseBase
     }
 
     /// <summary>
-    ///     Did server respond positively for 100 continue request?
+    ///     Gets a value indicating whether the server responded positively for 100 continue request.
     /// </summary>
     public bool ExpectationSucceeded { get; internal set; }
 
     /// <summary>
-    ///     Did server respond negatively for 100 continue request?
+    ///     Gets a value indicating whether the server responded negatively for 100 continue request.
     /// </summary>
     public bool ExpectationFailed { get; internal set; }
 

--- a/src/Titanium.Web.Proxy/Http/Response.cs
+++ b/src/Titanium.Web.Proxy/Http/Response.cs
@@ -22,25 +22,29 @@ public class Response : RequestResponseBase
     /// <summary>
     ///     Constructor.
     /// </summary>
+    /// <param name="body">The response body as a byte array.</param>
     public Response(byte[] body)
     {
         Body = body;
     }
 
     /// <summary>
-    ///     Response Status Code.
+    ///     Gets or sets the response status code.
     /// </summary>
     public int StatusCode { get; set; }
 
     /// <summary>
-    ///     Response Status description.
+    ///     Gets or sets the response status description.
     /// </summary>
     public string StatusDescription { get; set; } = string.Empty;
 
+    /// <summary>
+    ///     Gets or sets the request method associated with this response.
+    /// </summary>
     internal string? RequestMethod { get; set; }
 
     /// <summary>
-    ///     Has response body?
+    ///     Gets a value indicating whether the response has a body.
     /// </summary>
     public override bool HasBody
     {
@@ -68,7 +72,7 @@ public class Response : RequestResponseBase
     }
 
     /// <summary>
-    ///     Keep the connection alive?
+    ///     Gets a value indicating whether to keep the connection alive.
     /// </summary>
     public bool KeepAlive
     {
@@ -85,7 +89,7 @@ public class Response : RequestResponseBase
     }
 
     /// <summary>
-    ///     Gets the header text.
+    ///     Gets the header text of the response.
     /// </summary>
     public override string HeaderText
     {
@@ -98,6 +102,10 @@ public class Response : RequestResponseBase
         }
     }
 
+    /// <summary>
+    ///     Ensures the response body is available.
+    /// </summary>
+    /// <param name="throwWhenNotReadYet">If true, throws an exception if the body is not read yet.</param>
     internal override void EnsureBodyAvailable(bool throwWhenNotReadYet = true)
     {
         if (BodyInternal != null) return;
@@ -110,6 +118,13 @@ public class Response : RequestResponseBase
                                 "method to read the response body.");
     }
 
+    /// <summary>
+    ///     Parses the response line.
+    /// </summary>
+    /// <param name="httpStatus">The HTTP status line.</param>
+    /// <param name="version">The HTTP version.</param>
+    /// <param name="statusCode">The status code.</param>
+    /// <param name="statusDescription">The status description.</param>
     internal static void ParseResponseLine(string httpStatus, out Version version, out int statusCode,
         out string statusDescription)
     {


### PR DESCRIPTION
Related to #8

This pull request addresses the issue of missing XML documentation in the `Titanium.Web.Proxy` project by adding XML comments to public classes and their members in several HTTP-related files. 

- **Adds XML documentation**: Enhances `ConnectRequest.cs`, `ConnectResponse.cs`, `KnownHeader.cs`, `Request.cs`, and `Response.cs` with XML comments for public classes, properties, and methods. This includes descriptions for constructors, properties like `StatusCode`, `StatusDescription`, `Method`, `IsHttps`, and methods like `EnsureBodyAvailable`.
- **Improves code readability**: The added XML documentation provides developers and users of the library with better insights into the purpose and usage of the code, making it easier to understand and maintain.
- **Compliance with project standards**: Aligns with the project's goal to resolve all instances of the CS1591 warning by documenting publicly visible types or members, as highlighted in the issue.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/svrooij/titanium-web-proxy/issues/8?shareId=aa3ffa77-99f4-47a0-bdaa-613eace365f7).